### PR TITLE
Deploy heroku

### DIFF
--- a/Rasa_Bot/Dockerfile
+++ b/Rasa_Bot/Dockerfile
@@ -17,4 +17,4 @@ WORKDIR /app
 
 COPY . /app
 
-ENTRYPOINT ["rasa", "run", "--enable-api"]
+CMD ["rasa", "run", "--enable-api"]

--- a/Rasa_Bot/Dockerfile
+++ b/Rasa_Bot/Dockerfile
@@ -2,6 +2,10 @@
 
 FROM python:3.8
 
+# Heroku wants to provide a PORT env variable.
+# This default is here for runs outside heroku
+ENV PORT=5005
+
 # Change to root user to install dependencies
 USER root
 
@@ -17,4 +21,5 @@ WORKDIR /app
 
 COPY . /app
 
-CMD ["rasa", "run", "--enable-api"]
+# Using shell form to enable usage of port
+CMD rasa run --enable-api -p $PORT

--- a/Rasa_Bot/push_to_heroku.sh
+++ b/Rasa_Bot/push_to_heroku.sh
@@ -1,0 +1,16 @@
+# Guidelines for pushing to heroku
+# Make sure heroku cli is installed
+# Login to heroku
+heroku login
+
+# Make sure the right remote is configured
+heroku git:remote -a perfectfit-rasa-server
+
+# Login to container registry
+heroku container:login
+
+# Push web app
+heroku container:push:web
+
+# Deploy changes
+heroku container:release web

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,4 +1,4 @@
 build:
   docker:
-    web: Rasa_Bot/Dockerfile
+    web: ./Rasa_Bot/Dockerfile
 

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,4 @@
+build:
+  docker:
+    web: Rasa_Bot/Dockerfile
+


### PR DESCRIPTION
First part of issue #169 but not all of it.
Turns out I don't have as much free time (or energy) as I thought.

This part deploys the rasabot to heroku but not anything else.

I also created the script `push_to_heroku.sh` that shows the steps of how to do it.

There are multiple ways to deploy docker images to heroku but this one seemed best for our repo structure.
Heroku Apps can have a web and a worker component, but I think this repo might contain different separate workers. That is why I decided against using a `heroku.yml` file because I think it is not going to work. I believe there is only space for one web and one worker component in this configuration.