### PR TITLE
Less epochs for training TED

### DIFF
--- a/Rasa_Bot/config.yml
+++ b/Rasa_Bot/config.yml
@@ -28,7 +28,7 @@ policies:
     max_history: 5
   - name: TEDPolicy
     max_history: 10
-    epochs: 300
+    epochs: 50
     #augmentation: 50 # if 0, no augmentation of stories
   - name: RulePolicy
     core_fallback_threshold: 0.2 # NB: important to tune this carefully.


### PR DESCRIPTION
TED policy training already converges to near 100% accuracy after 30/40 epochs. With 50 epochs we are save. This saves a lot of time when training rasa core.