### PR TITLE
Trackerstore permissions

### DIFF
--- a/Rasa_Bot/Dockerfile
+++ b/Rasa_Bot/Dockerfile
@@ -15,9 +15,6 @@ RUN pip install -r requirements.txt
 RUN python -m spacy download nl_core_news_sm
 RUN python -m spacy link nl_core_news_sm nl
 
-# Don't use root user to run code
-# USER 1001
-
 # Use subdirectory as working directory
 WORKDIR /app
 
@@ -25,6 +22,7 @@ COPY . /app
 
 RUN chmod -R 777 /app
 
+# Don't use root user to run code
 USER 1001
 
 ENTRYPOINT ["rasa", "run", "--enable-api"]

--- a/Rasa_Bot/Dockerfile
+++ b/Rasa_Bot/Dockerfile
@@ -16,11 +16,15 @@ RUN python -m spacy download nl_core_news_sm
 RUN python -m spacy link nl_core_news_sm nl
 
 # Don't use root user to run code
-USER 1001
+# USER 1001
 
 # Use subdirectory as working directory
 WORKDIR /app
 
 COPY . /app
+
+RUN chmod -R 777 /app
+
+USER 1001
 
 ENTRYPOINT ["rasa", "run", "--enable-api"]


### PR DESCRIPTION
Fixes https://github.com/PerfectFit-project/virtual-coach-issues/issues/217 for now.

Problem was that the permissions did not allow the tracker store to be created on Windows. There is a follow-up issue to revert these extensive new permissions later (https://github.com/PerfectFit-project/virtual-coach-issues/issues/216).