### PR TITLE
Storing User Preferences in DB

### DIFF
--- a/Rasa_Bot/actions/actions_preparation_dialogs.py
+++ b/Rasa_Bot/actions/actions_preparation_dialogs.py
@@ -120,11 +120,11 @@ class ValidateUserPreferencesForm(FormValidationAction):
         # using try-except to check for truth value
         try:
             res = bool(datetime.strptime(timestring, format))
-            logging.info("res is now:" + res)
+            logging.info("res is now: " + str(res))
         except ValueError:
             res = False
 
-        logging.info("after the value error line res is:" + res)
+        logging.info("after the value error line res is: " + str(res))
 
         if not res:
             dispatcher.utter_message(text=f"Please submit an answer as given by the example: 20:34:20")

--- a/Rasa_Bot/actions/actions_preparation_dialogs.py
+++ b/Rasa_Bot/actions/actions_preparation_dialogs.py
@@ -3,7 +3,6 @@ Contains custom actions related to the preparation dialogs
 """
 from typing import Text, Any, Dict
 from datetime import datetime
-##import logging
 
 from rasa_sdk import Tracker, FormValidationAction, Action
 from rasa_sdk.events import SlotSet
@@ -11,11 +10,8 @@ from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.types import DomainDict
 from virtual_coach_db.helper.definitions import PreparationInterventionComponents
 
-##from virtual_coach_db.helper.helper_functions import get_db_session
 from .helper import (store_user_preferences_to_db, get_intervention_component_id,
                      week_day_to_numerical_form)
-from virtual_coach_db.dbschema.models import (Users, DialogAnswers, UserInterventionState,
-                                              InterventionComponents)
 
 YES_OR_NO = ["yes", "no"]
 ALLOWED_WEEK_DAYS = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
@@ -85,6 +81,7 @@ class ValidateUserPreferencesForm(FormValidationAction):
         tracker: Tracker,
         domain: DomainDict,
     ) -> Dict[Text, Any]:
+        # pylint: disable=unused-argument
         """Validate recursive_reminder` value."""
         if slot_value.lower() not in YES_OR_NO:
             dispatcher.utter_message(text="We only accept 'yes' or 'no' as answers")
@@ -99,6 +96,7 @@ class ValidateUserPreferencesForm(FormValidationAction):
         tracker: Tracker,
         domain: DomainDict,
     ) -> Dict[Text, Any]:
+        # pylint: disable=unused-argument
         """Validate `week_days` value."""
 
         week_days_string = slot_value
@@ -124,6 +122,7 @@ class ValidateUserPreferencesForm(FormValidationAction):
         tracker: Tracker,
         domain: DomainDict,
     ) -> Dict[Text, Any]:
+        # pylint: disable=unused-argument
         """Validate `time_stamp` value."""
 
         timestring = slot_value
@@ -174,5 +173,6 @@ class StoreUserPreferencesToDb(Action):
 
         datetime_format = datetime.strptime(preferred_time_string, '%H:%M:%S')
 
-        store_user_preferences_to_db(user_id, intervention_component, recursive_bool, week_days_numbers.rstrip(week_days_numbers[-1]), datetime_format)
+        store_user_preferences_to_db(user_id, intervention_component, recursive_bool,
+                                week_days_numbers.rstrip(week_days_numbers[-1]), datetime_format)
         return

--- a/Rasa_Bot/actions/actions_preparation_dialogs.py
+++ b/Rasa_Bot/actions/actions_preparation_dialogs.py
@@ -175,4 +175,3 @@ class StoreUserPreferencesToDb(Action):
 
         store_user_preferences_to_db(user_id, intervention_component, recursive_bool,
                                 week_days_numbers.rstrip(week_days_numbers[-1]), datetime_format)
-        return

--- a/Rasa_Bot/actions/actions_preparation_dialogs.py
+++ b/Rasa_Bot/actions/actions_preparation_dialogs.py
@@ -109,20 +109,24 @@ class ValidateUserPreferencesForm(FormValidationAction):
         tracker: Tracker,
         domain: DomainDict,
     ) -> Dict[Text, Any]:
-        """Validate `week_days` value."""
+        """Validate `time_stamp` value."""
 
         logging.info("timestamp 1")
         timestring = slot_value
         format = "%H:%M:%S"
-        res = True
+        res = False
 
+        logging.info("res initialized")
         # using try-except to check for truth value
         try:
             res = bool(datetime.strptime(timestring, format))
+            logging.info("res is now:" + res)
         except ValueError:
             res = False
 
-        if res:
+        logging.info("after the value error line res is:" + res)
+
+        if not res:
             dispatcher.utter_message(text=f"Please submit an answer as given by the example: 20:34:20")
             return {"time_stamp": None}
         dispatcher.utter_message(text=f"OK! You want to receive reminders at {slot_value}.")

--- a/Rasa_Bot/actions/actions_preparation_dialogs.py
+++ b/Rasa_Bot/actions/actions_preparation_dialogs.py
@@ -1,18 +1,19 @@
 """
 Contains custom actions related to the preparation dialogs
 """
-from typing import Text, List, Any, Dict
+from typing import Text, Any, Dict
 from datetime import datetime
-import logging
+##import logging
 
 from rasa_sdk import Tracker, FormValidationAction, Action
-from rasa_sdk.events import EventType, SlotSet
+from rasa_sdk.events import SlotSet
 from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.types import DomainDict
 from virtual_coach_db.helper.definitions import PreparationInterventionComponents
 
-from virtual_coach_db.helper.helper_functions import get_db_session
-from .helper import (store_user_preferences_to_db, get_intervention_component_id, week_day_to_numerical_form)
+##from virtual_coach_db.helper.helper_functions import get_db_session
+from .helper import (store_user_preferences_to_db, get_intervention_component_id,
+                     week_day_to_numerical_form)
 from virtual_coach_db.dbschema.models import (Users, DialogAnswers, UserInterventionState,
                                               InterventionComponents)
 
@@ -86,7 +87,7 @@ class ValidateUserPreferencesForm(FormValidationAction):
     ) -> Dict[Text, Any]:
         """Validate recursive_reminder` value."""
         if slot_value.lower() not in YES_OR_NO:
-            dispatcher.utter_message(text=f"We only accept 'yes' or 'no' as answers")
+            dispatcher.utter_message(text="We only accept 'yes' or 'no' as answers")
             return {"recursive_reminder": None}
         dispatcher.utter_message(text=f"OK! You have answered {slot_value}.")
         return {"recursive_reminder": slot_value}
@@ -109,9 +110,11 @@ class ValidateUserPreferencesForm(FormValidationAction):
                 invalidinput = True
 
         if invalidinput:
-            dispatcher.utter_message(text=f"Please submit the days of the week as a comma separated list!")
+            dispatcher.utter_message(text="Please submit the days of the week as" +
+                                          " a comma separated list!")
             return {"week_days": None}
-        dispatcher.utter_message(text=f"OK! You want to receive reminders on these days of the week: {slot_value}.")
+        dispatcher.utter_message(text="OK! You want to receive reminders on these" +
+                                      f" days of the week: {slot_value}.")
         return {"week_days": slot_value}
 
     def validate_time_stamp(
@@ -124,17 +127,18 @@ class ValidateUserPreferencesForm(FormValidationAction):
         """Validate `time_stamp` value."""
 
         timestring = slot_value
-        format = "%H:%M:%S"
+        timeformat = "%H:%M:%S"
         res = False
 
         # using try-except to check for truth value
         try:
-            res = bool(datetime.strptime(timestring, format))
+            res = bool(datetime.strptime(timestring, timeformat))
         except ValueError:
             res = False
 
         if not res:
-            dispatcher.utter_message(text=f"Please submit an answer as given by the example: 20:34:20")
+            dispatcher.utter_message(text="Please submit an answer as given by the example:" +
+                                          " 20:34:20")
             return {"time_stamp": None}
         dispatcher.utter_message(text=f"OK! You want to receive reminders at {slot_value}.")
         return {"time_stamp": slot_value}
@@ -151,7 +155,7 @@ class StoreUserPreferencesToDb(Action):
         preferred_time_string = tracker.get_slot("time_stamp")
 
         recursive_bool = False
-        if recursive == "yes" or recursive == "Yes":
+        if recursive in ('yes', 'Yes'):
             recursive_bool = True
 
         week_days_numbers = ""
@@ -161,8 +165,9 @@ class StoreUserPreferencesToDb(Action):
             week_days_numbers += ","
 
         ##TODO Set the slot in rasa
-        # When calling this in the right context, the intervention component slot should have a value.
-        # Uncomment the next two lines and remove the one under those two to switch from a hardcoded intervention component to the one decided by the slot.
+        # When calling this in the right context, the intervention component slot should have
+        # a value.Uncomment the next two lines and remove the one under those two to switch
+        # from a hardcoded intervention component to the one decided by the slot.
         ##intervention_component_string = tracker.get_slot("current_intervention_component")
         ##intervention_component = get_intervention_component_id(intervention_component_string)
         intervention_component = get_intervention_component_id("profile_creation")

--- a/Rasa_Bot/actions/actions_preparation_dialogs.py
+++ b/Rasa_Bot/actions/actions_preparation_dialogs.py
@@ -1,11 +1,17 @@
 """
 Contains custom actions related to the preparation dialogs
 """
+from typing import Text, List, Any, Dict
+from datetime import datetime
 
-from rasa_sdk import Action
-from rasa_sdk.events import SlotSet
+from rasa_sdk import Tracker, FormValidationAction, Action
+from rasa_sdk.events import EventType, SlotSet
+from rasa_sdk.executor import CollectingDispatcher
+from rasa_sdk.types import DomainDict
 from virtual_coach_db.helper.definitions import PreparationInterventionComponents
 
+YES_OR_NO = ["yes", "no"]
+ALLOWED_WEEK_DAYS = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
 
 ### Slot-setting methods called for rasa to store current intervention component
 class SetSlotProfileCreation(Action):
@@ -60,3 +66,62 @@ class SetSlotGoalSetting(Action):
     async def run(self, dispatcher, tracker, domain):
         return [SlotSet("current_intervention_component",
                         PreparationInterventionComponents.GOAL_SETTING)]
+
+class ValidateUserPreferencesForm(FormValidationAction):
+    def name(self) -> Text:
+        return "validate_user_preferences_form"
+
+    def validate_recursive_reminder(
+        self,
+        slot_value: Any,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: DomainDict,
+    ) -> Dict[Text, Any]:
+        """Validate recursive_reminder` value."""
+
+        if slot_value.lower() not in YES_OR_NO:
+            dispatcher.utter_message(text=f"We only accept 'yes' or 'no' as answers")
+            return {"recursive_reminder": None}
+        dispatcher.utter_message(text=f"OK! You have answered {slot_value}.")
+        return {"recursive_reminder": slot_value}
+
+    def validate_week_days(
+        self,
+        slot_value: Any,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: DomainDict,
+    ) -> Dict[Text, Any]:
+        """Validate `week_days` value."""
+
+        if slot_value not in ALLOWED_WEEK_DAYS:
+            dispatcher.utter_message(text=f"I don't recognize that day of the week, try again!")
+            return {"week_days": None}
+        dispatcher.utter_message(text=f"OK! You want to receive reminders on {slot_value}s.")
+        return {"week_days": slot_value}
+
+    def validate_time_stamp(
+        self,
+        slot_value: Any,
+        dispatcher: CollectingDispatcher,
+        tracker: Tracker,
+        domain: DomainDict,
+    ) -> Dict[Text, Any]:
+        """Validate `week_days` value."""
+
+        timestring = slot_value
+        format = "%H:%M:%S"
+        res = True
+
+        # using try-except to check for truth value
+        try:
+            res = bool(datetime.strptime(timestring, format))
+        except ValueError:
+            res = False
+
+        if res:
+            dispatcher.utter_message(text=f"Please submit an answer as given by the example: 20:34:20")
+            return {"time_stamp": None}
+        dispatcher.utter_message(text=f"OK! You want to receive reminders at {slot_value}.")
+        return {"time_stamp": slot_value}

--- a/Rasa_Bot/actions/actions_preparation_dialogs.py
+++ b/Rasa_Bot/actions/actions_preparation_dialogs.py
@@ -3,6 +3,7 @@ Contains custom actions related to the preparation dialogs
 """
 from typing import Text, List, Any, Dict
 from datetime import datetime
+import logging
 
 from rasa_sdk import Tracker, FormValidationAction, Action
 from rasa_sdk.events import EventType, SlotSet
@@ -79,7 +80,7 @@ class ValidateUserPreferencesForm(FormValidationAction):
         domain: DomainDict,
     ) -> Dict[Text, Any]:
         """Validate recursive_reminder` value."""
-
+        logging.info("recursive reminder validation 1")
         if slot_value.lower() not in YES_OR_NO:
             dispatcher.utter_message(text=f"We only accept 'yes' or 'no' as answers")
             return {"recursive_reminder": None}
@@ -94,7 +95,7 @@ class ValidateUserPreferencesForm(FormValidationAction):
         domain: DomainDict,
     ) -> Dict[Text, Any]:
         """Validate `week_days` value."""
-
+        logging.info("week days 1")
         if slot_value not in ALLOWED_WEEK_DAYS:
             dispatcher.utter_message(text=f"I don't recognize that day of the week, try again!")
             return {"week_days": None}
@@ -110,6 +111,7 @@ class ValidateUserPreferencesForm(FormValidationAction):
     ) -> Dict[Text, Any]:
         """Validate `week_days` value."""
 
+        logging.info("timestamp 1")
         timestring = slot_value
         format = "%H:%M:%S"
         res = True

--- a/Rasa_Bot/actions/helper.py
+++ b/Rasa_Bot/actions/helper.py
@@ -2,10 +2,11 @@
 Helper functions for rasa actions
 """
 import datetime
-import logging
+##import logging
 
 from .definitions import DialogQuestions, DATABASE_URL, TIMEZONE
-from virtual_coach_db.dbschema.models import (Users, DialogAnswers, InterventionComponents, UserPreferences)
+from virtual_coach_db.dbschema.models import (Users, DialogAnswers, InterventionComponents,
+                                              UserPreferences)
 from virtual_coach_db.helper.helper_functions import get_db_session
 
 
@@ -19,7 +20,8 @@ def store_dialog_answer_to_db(user_id, answer, question: DialogQuestions):
     selected.dialog_answers.append(entry)
     session.commit()  # Update database
 
-def store_user_preferences_to_db(user_id, intervention_component, recursive, week_days, preferred_time):
+def store_user_preferences_to_db(user_id, intervention_component, recursive, week_days,
+                                 preferred_time):
     session = get_db_session(db_url=DATABASE_URL)  # Create session object to connect db
     selected = session.query(Users).filter_by(nicedayuid=user_id).one()
 
@@ -56,17 +58,17 @@ def get_intervention_component_id(intervention_component_name: str) -> int:
 def week_day_to_numerical_form(week_day):
     if week_day.lower() == "monday":
         return 1
-    elif week_day.lower() == "tuesday":
+    if week_day.lower() == "tuesday":
         return 2
-    elif week_day.lower() == "wednesday":
+    if week_day.lower() == "wednesday":
         return 3
-    elif week_day.lower() == "thursday":
+    if week_day.lower() == "thursday":
         return 4
-    elif week_day.lower() == "friday":
+    if week_day.lower() == "friday":
         return 5
-    elif week_day.lower() == "saturday":
+    if week_day.lower() == "saturday":
         return 6
-    elif week_day.lower() == "sunday":
+    if week_day.lower() == "sunday":
         return 7
     else:
         return -1

--- a/Rasa_Bot/actions/helper.py
+++ b/Rasa_Bot/actions/helper.py
@@ -2,7 +2,6 @@
 Helper functions for rasa actions
 """
 import datetime
-##import logging
 
 from .definitions import DialogQuestions, DATABASE_URL, TIMEZONE
 from virtual_coach_db.dbschema.models import (Users, DialogAnswers, InterventionComponents,

--- a/Rasa_Bot/actions/helper.py
+++ b/Rasa_Bot/actions/helper.py
@@ -70,5 +70,4 @@ def week_day_to_numerical_form(week_day):
         return 6
     if week_day.lower() == "sunday":
         return 7
-    else:
-        return -1
+    return -1

--- a/Rasa_Bot/data/nlu.yml
+++ b/Rasa_Bot/data/nlu.yml
@@ -82,6 +82,11 @@ nlu:
   examples: |
     - "EXTERNAL_trigger_goal_setting"
 
+- intent: submit_user_preferences
+  examples: |
+    - "I would like to submit my user preferences"
+    - "User preferences"
+
 - intent: oke
   examples: |
     - "Oke"

--- a/Rasa_Bot/data/rules.yml
+++ b/Rasa_Bot/data/rules.yml
@@ -24,3 +24,20 @@ rules:
   - action: action_set_cigarettes_tracker_reminder
   - action: utter_reminder_is_set
   - action: action_end_dialog
+
+- rule: Activate user preferences form
+  steps:
+  - intent: submit_user_preferences
+  - action: user_preferences_form
+  - active_loop: user_preferences_form
+
+- rule: Submit user preferences form
+  condition:
+  - active_loop: user_preferences_form
+  steps:
+  - action: user_preferences_form
+  - active_loop: null
+  - slot_was_set:
+    - requested_slot: null
+  - action: utter_confirm
+  - action: utter_user_preferences

--- a/Rasa_Bot/domain/domain_preparation_dialogs.yml
+++ b/Rasa_Bot/domain/domain_preparation_dialogs.yml
@@ -16,18 +16,27 @@ slots:
     mappings:
     - type: from_text
       not_intent: submit_user_preferences
+      conditions:
+      - active_loop: user_preferences_form
+        requested_slot: recursive_reminder
   week_days:
     type: text
     influence_conversation: true
     mappings:
     - type: from_text
       not_intent: submit_user_preferences
+      conditions:
+      - active_loop: user_preferences_form
+        requested_slot: week_days
   time_stamp:
     type: text
     influence_conversation: true
     mappings:
     - type: from_text
       not_intent: submit_user_preferences
+      conditions:
+      - active_loop: user_preferences_form
+        requested_slot: time_stamp
 
 forms:
   user_preferences_form:

--- a/Rasa_Bot/domain/domain_preparation_dialogs.yml
+++ b/Rasa_Bot/domain/domain_preparation_dialogs.yml
@@ -15,16 +15,19 @@ slots:
     influence_conversation: true
     mappings:
     - type: from_text
+      not_intent: submit_user_preferences
   week_days:
     type: text
     influence_conversation: true
     mappings:
     - type: from_text
+      not_intent: submit_user_preferences
   time_stamp:
     type: text
     influence_conversation: true
     mappings:
     - type: from_text
+      not_intent: submit_user_preferences
 
 forms:
   user_preferences_form:

--- a/Rasa_Bot/domain/domain_preparation_dialogs.yml
+++ b/Rasa_Bot/domain/domain_preparation_dialogs.yml
@@ -6,7 +6,32 @@ intents:
 - EXTERNAL_trigger_plan_quit_start
 - EXTERNAL_trigger_mental_contrasting
 - EXTERNAL_trigger_goal_setting
+- submit_user_preferences
 - oke
+
+slots:
+  recursive_reminder:
+    type: text
+    influence_conversation: true
+    mappings:
+    - type: from_text
+  week_days:
+    type: text
+    influence_conversation: true
+    mappings:
+    - type: from_text
+  time_stamp:
+    type: text
+    influence_conversation: true
+    mappings:
+    - type: from_text
+
+forms:
+  user_preferences_form:
+    required_slots:
+      - recursive_reminder
+      - week_days
+      - time_stamp
 
 
 responses:
@@ -23,6 +48,16 @@ responses:
    - text: "Conducting mental contrasting talk..."
   utter_goal_setting:
    - text: "Setting goals..."
+  utter_ask_recursive_reminder:
+   - text: "Do you want us to give you daily reminders?"
+  utter_ask_week_days:
+    - text: "On what days would you want to be reminded?"
+  utter_ask_time_stamp:
+    - text: "What time would you want your reminders?"
+  utter_confirm:
+   - text: "Confirmed."
+  utter_user_preferences:
+   - text: "Your selected preferences are..."
 
 actions:
 ### Preparation Phase actions
@@ -32,3 +67,4 @@ actions:
 - action_set_slot_plan_quit_start_date
 - action_set_slot_mental_contrasting
 - action_set_slot_goal_setting
+- validate_user_preferences_form

--- a/Rasa_Bot/story_graph.dot
+++ b/Rasa_Bot/story_graph.dot
@@ -1,0 +1,13 @@
+digraph  {
+0 [class="start active", fillcolor=green, fontsize=12, label=START, style=filled];
+"-1" [class=end, fillcolor=red, fontsize=12, label=END, style=filled];
+1 [class=active, fontsize=12, label=action_session_start];
+2 [class=active, fontsize=12, label=user_preferences_form];
+3 [class="dashed active", fontsize=12, label=utter_confirm];
+4 [class="intent active", fillcolor=lightblue, label="/submit_user_preferences", shape=rect, style=filled];
+0 -> "-1"  [class="", key=NONE, label=""];
+0 -> 1  [class=active, key=NONE, label=""];
+1 -> 4  [class=active, key=0];
+2 -> 3  [class=active, key=NONE, label=""];
+4 -> 2  [class=active, key=0];
+}


### PR DESCRIPTION
Added functionality to trigger a form by typing in 'user preferences'. The form will ask for the users preferences and validate each input, and will subsequently store the preferences in the database. 
In order to test this functionality the .env file in the main repo needs to be changed so that the TEST_USER_ID is the ID of the device that is being tested from.