### PR TITLE
Oefening persuasion

### DIFF
--- a/Rasa_Bot/actions/definitions.py
+++ b/Rasa_Bot/actions/definitions.py
@@ -2,9 +2,9 @@
 Stores definitions used in rasa actions, related to database, endpoints, timezone etcetera.
 """
 import os
+from dateutil import tz
 from enum import Enum
 
-from dateutil import tz
 
 # load database url and niceday_api_endpoint variables
 DATABASE_URL = os.getenv('DATABASE_URL')
@@ -31,13 +31,14 @@ DAYPART_NAMES_DUTCH = ["ochtend", "middag", "avond"]
 # Start with the last one, needed for breaking out of confidence slot asking
 PROFILE_CREATION_CONF_SLOTS = ["profile_creation_conf_" + str(i) + "_slot" for i in range(10, 0, 
                                                                                           -1)]
-    
 # number of activities displayed by the first aid kit
 NUM_TOP_ACTIVITIES = 5
 
 # Images for file sharing
 FILE_PATH_IMAGE_PA = '/app/hoe_intensief_beweeg_jij.jpg'
 
+### Persuasion in general activity dialog
+# Optimal policy based on the one computed in the paper by Albers et al. (2023)
 # Opt policy for [want][prompts][need]
 # Start at 1, since database values start at 1.
 # 1 = commitment, 2 = consensus, 3 = no persuasion
@@ -46,7 +47,9 @@ OPT_POLICY = [[[1, 2], [3, 2]],[[1, 1], [3, 1]]]
 # want, prompts, need 
 # (+1 compared to paper, because here values are from 1-5 (not 0-4))
 STATE_FEATURE_MEANS = [3.96, 3.74, 3.88]
-# Persuasive messages for the persuasion types of commitment and consensus
+# Persuasive messages for the persuasion types of commitment and consensus.
+# Adapted based on the ones used in the paper by Albers et al. (2022)
+# (https://doi.org/10.1371/journal.pone.0277295)
 COMMITMENT = ["Vergeet niet: Je hebt besloten om gezonder te gaan leven. "\
                  "Het zal goed voelen wanneer je je aan deze belofte houdt.",
               "Vergeet niet: Je hebt besloten om gezonder te gaan leven. "\
@@ -58,24 +61,26 @@ COMMITMENT = ["Vergeet niet: Je hebt besloten om gezonder te gaan leven. "\
               "Vergeet niet: Je wilt graag gezonder gaan leven. Ik hoop dat je "\
                  "deze belofte niet breekt.",
               "Vergeet niet: Je hebt beloofd om iemand te worden die gezonder leeft. "\
-                 "Deze activiteit kan je helpen om deze persoon te worden.",
+                 "Deze oefening kan je helpen om deze persoon te worden.",
               "Vergeet niet: Je hebt beloofd om iemand te worden die gezonder leeft. "\
-                 "Als je deze activiteit NIET doet, kan het moeilijker zijn om "\
+                 "Als je deze oefening NIET doet, kan het moeilijker zijn om "\
                  "deze persoon te worden."]
-CONSENSUS = ["De meeste mensen denken dat deze activiteit zal helpen om",
-             "De meeste mensen denken dat als je deze activiteit NIET doet, "\
+CONSENSUS = ["De meeste mensen denken dat deze oefening zal helpen om",
+             "De meeste mensen denken dat als je deze oefening NIET doet, "\
                  "het moeilijker kan zijn om",
-             "Het grootste deel van de mensen gelooft dat deze activiteit zal helpen om",
-             "Het grootste deel van de mensen gelooft dat als je deze activiteit "\
+             "Het grootste deel van de mensen gelooft dat deze oefening zal helpen om",
+             "Het grootste deel van de mensen gelooft dat als je deze oefening "\
                  "NIET doet, het moeilijker kan zijn om"]
 # Reflective questions for persuasion types of commitment and consensus
+# Adapted based on the ones used in the paper by Albers et al. (2022)
+# (https://doi.org/10.1371/journal.pone.0277295)
 REFLECTIVE_QUESTION_COMMITMENT = "Je hebt het besluit genomen om gezonder te "\
-   "gaan leven. Hoe helpt deze activiteit jou hierbij?"
-REFLECTIVE_QUESTION_COMMITMENT_IDENTITY = "Hoe helpt deze activiteit jou bij "\
+   "gaan leven. Hoe helpt deze oefening jou hierbij?"
+REFLECTIVE_QUESTION_COMMITMENT_IDENTITY = "Hoe helpt deze oefening jou bij "\
    "jouw besluit om iemand te worden die gezonder leeft?"
-REFLECTIVE_QUESTION_CONSENSUS = "Hoe denk je dat deze activiteit iemand zoals "\
+REFLECTIVE_QUESTION_CONSENSUS = "Hoe denk je dat deze oefening iemand zoals "\
    "jou kan helpen om gezonder te gaan leven?"
-    
+
 # Accepted misspelled words for days of the weeks
 DAYS_OF_WEEK_ACCEPTED = {"maandag": ["maandag", "mandag", "maadag"],
                          "diensdag": ["dinsdag", "diensdag", "diensdah"],
@@ -88,7 +93,6 @@ DAYS_OF_WEEK_ACCEPTED = {"maandag": ["maandag", "mandag", "maadag"],
 # List of days of week in Dutch
 DAYS_OF_WEEK = ["maandag", "diensdag", "woensdag", "donderdag", "vrijdag",
                 "zaterdag", "zondag"]
-
 
 activities_categories = {1: 'self-related',
                          2: 'educational',

--- a/Rasa_Bot/domain/domain_general_activity.yml
+++ b/Rasa_Bot/domain/domain_general_activity.yml
@@ -282,7 +282,7 @@ responses:
     - text: "Wanneer je het moeilijk hebt kun je hier naar terugkijken."
     - text: "Hier kun je naar terugkijken op moeilijke momenten."
   utter_general_activity_thanks_top_5_1:
-    - text: "Bedankt voor je feedback. Je vindt deze activiteit nuttig. Daarom wordt deze toegevoegd aan je EHBO-doos."
+    - text: "Bedankt voor je feedback. Je vindt deze oefening nuttig. Daarom wordt deze toegevoegd aan je EHBO-doos."
     - text: "Dank je wel voor je feedback. We zijn blij dat je deze oefening nuttig vindt. Daarom voegen wij hem toe aan je EHBO-doos."
     - text: "Bedankt voor je reactie. Fijn dat deze oefening nuttig voor je is. Deze oefening wordt daarom toegevoegd aan je EHBO-doos."
 #  utter_what_you_learned_from_activity:
@@ -357,13 +357,15 @@ responses:
     - text: "Dan is het nu tijd om verder te gaan met een nieuwe oefening. Ik stel voor om de oefening '{chosen_activity_slot}' te doen. Veel succes!"
     - text: "Dan is het nu tijd om aan een nieuwe oefening te beginnen. Ik stel voor om de oefening '{chosen_activity_slot}' te doen. Ik wens je veel succes!"
   utter_persuasion_questions_intro:
-    - text: "Ik wil je nu graag een paar vragen stellen over de activiteit die je gaat doen."
-    - text: "Dan zou ik je nu graag wat vragen stellen over de activiteit die je gaat doen."
-    - text: "Ik zou je nu graag wat willen vragen over de activiteit die je gaat doen."
+    - text: "Ik wil je nu graag een paar vragen stellen over de oefening die je gaat doen."
+    - text: "Dan zou ik je nu graag wat vragen stellen over de oefening die je gaat doen."
+    - text: "Ik zou je nu graag wat willen vragen over de oefening die je gaat doen."
   utter_persuasion_questions_intro_2:
     - text: "Kun je mij laten weten wat je van de volgende uitspraken vindt?"
   utter_ask_persuasion_prompts_slot_intro:
-    - text: "1) Ik heb dingen die mij eraan herinneren om de activiteit te doen."
+    - text: "1) Ik heb dingen die mij eraan herinneren om de oefening te doen."
+  # Persuasion state questions translated to Dutch from the ones used in 
+  # the paper by Albers et al. (2023)
   utter_ask_persuasion_prompts_slot:
     - text: "1. Helemaal mee oneens\n 
             2. Mee oneens\n
@@ -372,7 +374,7 @@ responses:
             5. Helemaal mee eens.\n
             Typ '1', '2', '3', '4', of '5'."
   utter_ask_persuasion_want_slot_intro:
-    - text: "2) Ik heb het gevoel dat ik de activiteit wil gaan doen."
+    - text: "2) Ik heb het gevoel dat ik de oefening wil gaan doen."
   utter_ask_persuasion_want_slot:
     - text: "1. Helemaal mee oneens\n
              2. Mee oneens\n
@@ -381,7 +383,7 @@ responses:
              5. Helemaal mee eens.\n 
              Typ '1', '2', '3', '4', of '5'."
   utter_ask_persuasion_need_slot_intro:
-    - text: "3) Ik heb het gevoel dat ik de activiteit moet doen."
+    - text: "3) Ik heb het gevoel dat ik de oefening moet doen."
   utter_ask_persuasion_need_slot:
     - text: "1. Helemaal mee oneens\n
              2. Mee oneens\n

--- a/Rasa_Bot/domain/domain_general_activity.yml
+++ b/Rasa_Bot/domain/domain_general_activity.yml
@@ -362,10 +362,10 @@ responses:
     - text: "Ik zou je nu graag wat willen vragen over de oefening die je gaat doen."
   utter_persuasion_questions_intro_2:
     - text: "Kun je mij laten weten wat je van de volgende uitspraken vindt?"
-  utter_ask_persuasion_prompts_slot_intro:
-    - text: "1) Ik heb dingen die mij eraan herinneren om de oefening te doen."
   # Persuasion state questions translated to Dutch from the ones used in 
   # the paper by Albers et al. (2023)
+  utter_ask_persuasion_prompts_slot_intro:
+    - text: "1) Ik heb dingen die mij eraan herinneren om de oefening te doen."
   utter_ask_persuasion_prompts_slot:
     - text: "1. Helemaal mee oneens\n 
             2. Mee oneens\n


### PR DESCRIPTION
Fixes #https://github.com/PerfectFit-project/virtual-coach-issues/issues/356.

Based on feedback at the demo at the Persuasive Technology conference, replaced "activiteit" with "oefening" in persuasion in general activity dialog to be consistent with other dialogs.