### PR TITLE
Enhance plot of figure with steps and step goals

### DIFF
--- a/Rasa_Bot/actions/helper.py
+++ b/Rasa_Bot/actions/helper.py
@@ -1102,13 +1102,13 @@ def make_step_overview(date_array: List[str], step_array: List[int], step_goal: 
                             y=data['date'],
                             orientation='h',
                             marker=dict(color=data['goal_achieved'].map(
-                                {True: 'green', False: 'red'})),
+                                {True: 'lime', False: 'tomato'})),
                             showlegend=False
                             ),
                      go.Bar(x=data['goals'],
                             y=data['date'],
                             orientation='h',
-                            opacity=0.1,
+                            opacity=0.3,
                             showlegend=False)
                      ],
                     layout=go.Layout(barmode='overlay'))
@@ -1122,7 +1122,7 @@ def make_step_overview(date_array: List[str], step_array: List[int], step_goal: 
                            xshift=5)
 
     for i, step in enumerate(data['steps']):
-        fig.add_annotation(x=step / 2,
+        fig.add_annotation(x=1500,
                            y=i,
                            text=f'Steps: {step}',
                            showarrow=False,


### PR DESCRIPTION
Fixes: https://github.com/PerfectFit-project/virtual-coach-issues/issues/384

Note that it can still happen that the text for the actual steps and step goal can overlap, in case the number of steps and goal is around 3000... Check the before and after image in the issue: https://github.com/PerfectFit-project/virtual-coach-issues/issues/384