### PR TITLE
changed celery task in the actions

### DIFF
--- a/Rasa_Bot/actions/actions_preparation_phase.py
+++ b/Rasa_Bot/actions/actions_preparation_phase.py
@@ -9,7 +9,7 @@ from virtual_coach_db.helper.definitions import (Components,
                                                  DialogExpectedDuration)
 
 from . import validator
-from .definitions import MORNING, AFTERNOON, REDIS_URL, TIMEZONE
+from .definitions import MORNING, AFTERNOON, REDIS_URL, TIMEZONE, TRIGGER_INTENT
 from .helper import get_latest_bot_utterance
 from .actions_rescheduling_dialog import get_reschedule_date
 
@@ -100,9 +100,8 @@ class StartNextDialog(Action):
             return [FollowupAction('utter_profile_creation_start_3')]
 
         # if the dialog is a video one, launch the watch a video dialog
-        celery.send_task('celery_tasks.trigger_intervention_component',
-                         (user_id,
-                          ComponentsTriggers.WATCH_VIDEO))
+        celery.send_task(TRIGGER_INTENT,
+                         (user_id, ComponentsTriggers.WATCH_VIDEO))
 
 
 class ScheduleNextPrepPhase(Action):

--- a/Rasa_Bot/actions/actions_watching_a_video.py
+++ b/Rasa_Bot/actions/actions_watching_a_video.py
@@ -78,7 +78,7 @@ class DelayedMessage(Action):
 
         dialog = str(tracker.get_slot('current_intervention_component'))
         try:
-            duration = 10
+            duration = (DialogExpectedDuration[dialog]) * 60
         except Exception:
             duration = 30
 

--- a/Rasa_Bot/actions/actions_watching_a_video.py
+++ b/Rasa_Bot/actions/actions_watching_a_video.py
@@ -8,7 +8,7 @@ from typing import Text, Dict, Any
 from virtual_coach_db.helper.definitions import (VideoLinks, Components, ComponentsTriggers,
                                                  DialogExpectedDuration)
 from . import validator
-from .definitions import PAUSE_AND_TRIGGER, REDIS_URL
+from .definitions import PAUSE_AND_TRIGGER, REDIS_URL, TRIGGER_INTENT
 from .helper import get_latest_bot_utterance
 
 celery = Celery(broker=REDIS_URL)
@@ -23,7 +23,7 @@ class ActionLaunchWatchVideoDialog(Action):
     async def run(self, dispatcher, tracker, domain):
         user_id = int(tracker.current_state()['sender_id'])  # retrieve userID
         new_intent = ComponentsTriggers.WATCH_VIDEO
-        celery.send_task('celery_tasks.trigger_intervention_component',
+        celery.send_task(TRIGGER_INTENT,
                          (user_id, new_intent))
         return []
 
@@ -38,7 +38,7 @@ class ActionLaunchReschedulingPrep(Action):
         user_id = int(tracker.current_state()['sender_id'])  # retrieve userID
         new_intent = ComponentsTriggers.RESCHEDULING_PREPARATION
 
-        celery.send_task('celery_tasks.trigger_intervention_component',
+        celery.send_task(TRIGGER_INTENT,
                          (user_id, new_intent))
         return []
 
@@ -78,7 +78,7 @@ class DelayedMessage(Action):
 
         dialog = str(tracker.get_slot('current_intervention_component'))
         try:
-            duration = (DialogExpectedDuration[dialog]) * 60
+            duration = 10
         except Exception:
             duration = 30
 


### PR DESCRIPTION
Fixes: https://github.com/PerfectFit-project/virtual-coach-issues/issues/388
Fixes: https://github.com/PerfectFit-project/virtual-coach-issues/issues/391
Fixes: https://github.com/PerfectFit-project/testing-tickets/issues/22
Fixes: https://github.com/PerfectFit-project/testing-tickets/issues/23

The problem was that the type of task that was sent to the scheduler by the video dialogs was wrong. What happened was that the just the generic `watch_video_dialog` and `reschedule_preparation_phase` dialogs where stored in the FSM. If the dialog expired, and the FSM rescheduled it, the wrong element was saved in the DB, and it was never marked as completed.
