### PR TITLE
390 pause after profile creation

### DIFF
--- a/scheduler/celery_tasks.py
+++ b/scheduler/celery_tasks.py
@@ -408,7 +408,9 @@ def pause_and_trigger(self,  # pylint: disable=unused-argument
         user_id: the ID of the user to send the trigger to
         trigger: the intent to be sent
         time: time for scheduling the dialog resume
-        acknowledge: if true, use the trigger_intervention_component task, to acknowledge the FSM
+        acknowledge: if true, use the trigger_intervention_component task, to acknowledge the FSM.
+        When the FSM in acknowledged, the trigger will result in the full process of starting a new
+        dialog, so new entry is added to the DB and the starting time of the dialog is updated.
     """
     pause_conversation.apply_async(args=[user_id])
     resume_and_trigger.apply_async(args=[user_id, trigger, acknowledge], eta=time)

--- a/scheduler/celery_tasks.py
+++ b/scheduler/celery_tasks.py
@@ -460,7 +460,8 @@ def resume_and_trigger(self,  # pylint: disable=unused-argument
         raise Exception()
 
     if acknowledge:
-        trigger_intervention_component(user_id, trigger)
+        trigger_intervention_component.apply_async(
+            args=[user_id, trigger])
 
     else:
         response_intent = send_trigger(user_id, trigger)

--- a/scheduler/celery_tasks.py
+++ b/scheduler/celery_tasks.py
@@ -400,16 +400,18 @@ def pause_and_resume(self,  # pylint: disable=unused-argument
 def pause_and_trigger(self,  # pylint: disable=unused-argument
                       user_id: int,
                       trigger: str,
-                      time: datetime):
+                      time: datetime,
+                      acknowledge: bool = False):
     """
     This task sends a pause the dialog and schedules the resume.
     Args:
         user_id: the ID of the user to send the trigger to
         trigger: the intent to be sent
         time: time for scheduling the dialog resume
+        acknowledge: if true, use the trigger_intervention_component task, to acknowledge the FSM
     """
     pause_conversation.apply_async(args=[user_id])
-    resume_and_trigger.apply_async(args=[user_id, trigger], eta=time)
+    resume_and_trigger.apply_async(args=[user_id, trigger, acknowledge], eta=time)
 
 
 @app.task(bind=True, autoretry_for=(Exception,), retry_backoff=True)
@@ -440,12 +442,14 @@ def resume(self,  # pylint: disable=unused-argument
 @app.task(bind=True, autoretry_for=(Exception,), retry_backoff=True)
 def resume_and_trigger(self,  # pylint: disable=unused-argument
                        user_id: int,
-                       trigger: str):
+                       trigger: str,
+                       acknowledge: bool = False):
     """
     This task sends a resume event to Rasa and triggers a new intent.
     Args:
         user_id: the ID of the user to send the trigger to
         trigger: the intent to be sent after the dialog is resumed
+        acknowledge: if true, use the trigger_intervention_component task, to acknowledge the FSM
     """
     endpoint = f'http://rasa_server:5005/conversations/{user_id}/tracker/events'
     headers = {'Content-Type': 'application/json'}
@@ -455,10 +459,14 @@ def resume_and_trigger(self,  # pylint: disable=unused-argument
     if response_resume.status_code != 200:
         raise Exception()
 
-    response_intent = send_trigger(user_id, trigger)
-    if response_intent != 200:
-        logging.info('Exception during resume_and_trigger')
-        raise Exception()
+    if acknowledge:
+        trigger_intervention_component(user_id, trigger)
+
+    else:
+        response_intent = send_trigger(user_id, trigger)
+        if response_intent != 200:
+            logging.info('Exception during resume_and_trigger')
+            raise Exception()
 
 
 def send_trigger(user_id: int, trigger: str):

--- a/scheduler/state_machine/const.py
+++ b/scheduler/state_machine/const.py
@@ -38,6 +38,7 @@ ENVIRONMENT = os.getenv('ENVIRONMENT')
 DATABASE_URL = os.getenv('DATABASE_URL')
 NICEDAY_API_ENDPOINT = os.getenv('NICEDAY_API_ENDPOINT')
 TRIGGER_COMPONENT = 'celery_tasks.trigger_intervention_component'
+PAUSE_AND_TRIGGER = 'celery_tasks.pause_and_trigger'
 SCHEDULE_TRIGGER_COMPONENT = 'celery_tasks.trigger_scheduled_intervention_component'
 TRIGGER_INTENT = 'celery_tasks.trigger_intent'
 TIMEZONE = tz.gettz("Europe/Amsterdam")

--- a/scheduler/state_machine/controller.py
+++ b/scheduler/state_machine/controller.py
@@ -1,4 +1,5 @@
 import logging
+from celery import Celery
 from datetime import date, datetime, timedelta
 from state_machine.state_machine_utils import (create_new_date, dialog_to_be_completed,
                                                get_dialog_completion_state,
@@ -9,13 +10,15 @@ from state_machine.state_machine_utils import (create_new_date, dialog_to_be_com
                                                retrieve_intervention_day, revoke_execution,
                                                run_uncompleted_dialog, run_option_menu,
                                                schedule_next_execution, store_completed_dialog,
-                                               update_execution_week)
+                                               update_execution_week, store_scheduled_dialog)
 from state_machine.const import (ACTIVITY_C2_9_DAY_TRIGGER, FUTURE_SELF_INTRO, GOAL_SETTING,
-                                 TRACKING_DURATION, TIMEZONE, PREPARATION_GA,
+                                 TRACKING_DURATION, TIMEZONE, PREPARATION_GA, PAUSE_AND_TRIGGER,
                                  MAX_PREPARATION_DURATION, LOW_PA_GROUP, HIGH_PA_GROUP,
-                                 EXECUTION_DURATION_WEEKS,TIME_DELTA_PA_NOTIFICATION)
+                                 EXECUTION_DURATION_WEEKS, TIME_DELTA_PA_NOTIFICATION, REDIS_URL)
 from state_machine.state import State
-from virtual_coach_db.helper.definitions import (Components, Notifications)
+from virtual_coach_db.helper.definitions import (Components, ComponentsTriggers, Notifications)
+
+celery = Celery(broker=REDIS_URL)
 
 
 class OnboardingState(State):
@@ -41,10 +44,24 @@ class OnboardingState(State):
 
         elif dialog == Components.PROFILE_CREATION:
             logging.info('Profile creation completed, starting med talk')
-            plan_and_store(user_id=self.user_id,
-                           dialog=Components.MEDICATION_TALK,
-                           planned_date=datetime.now() + timedelta(seconds=30),
-                           phase_id=1)
+
+            dialog_id = get_intervention_component(
+                Components.MEDICATION_TALK).intervention_component_id
+
+            trigger_time = datetime.now() + timedelta(seconds=30)
+            # store record in db
+            store_scheduled_dialog(user_id=self.user_id,
+                                   dialog_id=dialog_id,
+                                   phase_id=1,
+                                   planned_date=trigger_time,
+                                   last_time=trigger_time)
+
+            # pause the conversation and then trigger the dialog
+            celery.send_task(PAUSE_AND_TRIGGER,
+                             (self.user_id,
+                              ComponentsTriggers.MEDICATION_TALK,
+                              datetime.now() + timedelta(seconds=30),
+                              True))
 
         elif dialog == Components.MEDICATION_TALK:
             logging.info('Med talk completed, starting track behavior')
@@ -74,7 +91,7 @@ class OnboardingState(State):
                           phase=1)
 
     def on_user_trigger(self, dialog):
-        if dialog in(Components.FIRST_AID_KIT, dialog == Components.FIRST_AID_KIT_VIDEO):
+        if dialog in (Components.FIRST_AID_KIT, dialog == Components.FIRST_AID_KIT_VIDEO):
             # dialog not available in this phase
             if dialog_to_be_completed(self.user_id) is None:
                 complete = False


### PR DESCRIPTION
Fixes: https://github.com/PerfectFit-project/virtual-coach-issues/issues/390
Fixes: https://github.com/PerfectFit-project/testing-tickets/issues/19

After the completion of the profile creation dialog, the conversation is now paused for 30 seconds before triggering the next dialog. The pause is necessary for two reasons: 
- we cannot triggered immediately the next dialog, because the messages of the profile will be dispatched also during the new dialog (due to the time delay used between the messages)
- if the user types something during between the two dialogs, mixed messages will be received