### PR TITLE
Fixing the verder problem

### DIFF
--- a/scheduler/celery_tasks.py
+++ b/scheduler/celery_tasks.py
@@ -194,6 +194,9 @@ def check_inactivity():
     state_machines = get_all_fsm()
     for item in state_machines:
         if not check_if_user_active(item.machine_id, current_date, MAXIMUM_INACTIVE_DAYS):
+            current_dialog_state = get_dialog_state(item)
+            if current_dialog_state == RUNNING:
+                return
             trigger_intent.apply_async(args=[item.machine_id,
                                              NotificationsTriggers.INACTIVE_USER_NOTIFICATION])
 
@@ -344,12 +347,6 @@ def trigger_intent(self,  # pylint: disable=unused-argument
         trigger: the intent to be sent
         dialog_status: set the dialog state in the fsm
     """
-    # make sure that a dialog is not running when sending the intent
-    user_fsm = get_user_fsm(user_id)
-    current_dialog_state = get_dialog_state(user_fsm)
-    if current_dialog_state == RUNNING:
-        return
-
     response_intent = send_trigger(user_id, trigger)
 
     if response_intent != 200:


### PR DESCRIPTION
Fixes https://github.com/PerfectFit-project/virtual-coach-issues/issues/398

The 'verder' command was received. It triggered the dialog correctly, but for the dialogs where the rescheduling was used, the first thing that happened was that rasa requested the 'rescheduling dialog' to be triggered. As the dialog was seen already as running, the scheduler did not execute this.
This check is actually needed just for the notifications, so it has been moved there.