### PR TITLE
Avoid messages in the night

### DIFF
--- a/Rasa_Bot/actions/actions_rescheduling_dialog.py
+++ b/Rasa_Bot/actions/actions_rescheduling_dialog.py
@@ -10,9 +10,9 @@ from rasa_sdk.events import FollowupAction, SlotSet
 from rasa_sdk.executor import CollectingDispatcher
 from rasa_sdk.forms import FormValidationAction
 
-from .definitions import REDIS_URL
-from .definitions import TIMEZONE
-from .definitions import MORNING, AFTERNOON, EVENING
+from .definitions import (MORNING, AFTERNOON, EVENING,
+                          MORNING_SEND_TIME, AFTERNOON_SEND_TIME, EVENING_SEND_TIME,
+                          REDIS_URL, TIMEZONE)
 from .helper import get_latest_bot_utterance
 from . import validator
 
@@ -80,9 +80,9 @@ def get_reschedule_date(timestamp: float, choice: int) -> datetime.datetime:
 
     dt_object = datetime.datetime.fromtimestamp(timestamp, TIMEZONE)
 
-    morning_time = dt_object.replace(hour=8, minute=0, second=0)
-    afternoon_time = dt_object.replace(hour=16, minute=0, second=0)
-    evening_time = dt_object.replace(hour=21, minute=0, second=0)
+    morning_time = dt_object.replace(hour=MORNING_SEND_TIME, minute=0, second=0)
+    afternoon_time = dt_object.replace(hour=AFTERNOON_SEND_TIME, minute=0, second=0)
+    evening_time = dt_object.replace(hour=EVENING_SEND_TIME, minute=0, second=0)
 
     if choice == 1:
         reschedule_time = dt_object + datetime.timedelta(hours=1)

--- a/Rasa_Bot/actions/definitions.py
+++ b/Rasa_Bot/actions/definitions.py
@@ -39,9 +39,9 @@ AFTERNOON = (12, 18)
 EVENING = (18, 24)
 
 # Times to start components during times
-MORNING_SEND_TIME = 7
-AFTERNOON_SEND_TIME = 15
-EVENING_SEND_TIME  = 20
+MORNING_SEND_TIME = 8
+AFTERNOON_SEND_TIME = 16
+EVENING_SEND_TIME = 21
 
 # Daypart names in Dutch
 DAYPART_NAMES_DUTCH = ["ochtend", "middag", "avond"]

--- a/scheduler/celery_tasks.py
+++ b/scheduler/celery_tasks.py
@@ -163,7 +163,7 @@ def check_dialogs_status(self):  # pylint: disable=unused-argument
     # this check should not run between 23 and 7
     current_date = datetime.now(tz=TIMEZONE)
 
-    if current_date.hour == 23 or current_date.hour < MORNING_TIME:
+    if 0 < current_date.hour < MORNING_TIME:
         return
 
     logging.info("Checking the dialogs status")

--- a/scheduler/celery_tasks.py
+++ b/scheduler/celery_tasks.py
@@ -159,6 +159,13 @@ def check_dialogs_status(self):  # pylint: disable=unused-argument
     This task verifies if there are uncompleted dialogs and, in case, reschedules them.
     The task is rescheduled every maximum duration of the dialog time
     """
+
+    # this check should not run between 23 and 7
+    current_date = datetime.now(tz=TIMEZONE)
+
+    if current_date.hour == 23 or current_date.hour < 7:
+        return
+
     logging.info("Checking the dialogs status")
 
     state_machines = get_all_fsm()
@@ -243,9 +250,15 @@ def reschedule_dialog(user_id: int, intervention_component_name: str, new_date: 
     """
 
     logging.info('Celery received a dialog rescheduling')
+
+    # check if the scheduled time is in the night (i.e., after midnight and before 6)
+    # In case it is, reschedule for the morning.
+    if 0 <= new_date.hour <= 5:
+        new_date.replace(hour=8)
+
     send_fsm_event(user_id=user_id,
                    event=Event(EventEnum.DIALOG_RESCHEDULED_USER,
-                               (intervention_component_name, new_date)))
+                               (intervention_component_name, new_date.astimezone(TIMEZONE))))
 
 
 @app.task(autoretry_for=(Exception,), retry_backoff=True)
@@ -304,6 +317,16 @@ def trigger_scheduled_intervention_component(self,
 
     # retrieve the name of the component
     name = get_component_name(trigger)
+
+    # check if the current time is in the night (i.e., after midnight and before 6)
+    # In case it is, reschedule for the morning.
+    current_date = datetime.now(tz=TIMEZONE)
+    if 0 <= current_date.hour <= 5:
+        current_date.replace(hour=8)
+        send_fsm_event(user_id,
+                       event=Event(EventEnum.DIALOG_RESCHEDULED_AUTO, (name, current_date)))
+
+        return
 
     # if a dialog is not running or the time has expired (Rasa session reset)
     # send the trigger

--- a/scheduler/state_machine/const.py
+++ b/scheduler/state_machine/const.py
@@ -50,4 +50,4 @@ EXPIRED = 2
 NOTIFY = 3
 
 # definitions of morning hours
-MORNING_TIME = 7
+MORNING_TIME = 8

--- a/scheduler/state_machine/const.py
+++ b/scheduler/state_machine/const.py
@@ -48,3 +48,6 @@ NOT_RUNNING = 0
 RUNNING = 1
 EXPIRED = 2
 NOTIFY = 3
+
+# definitions of morning hours
+MORNING_TIME = 7

--- a/scheduler/state_machine/state_machine_utils.py
+++ b/scheduler/state_machine/state_machine_utils.py
@@ -805,6 +805,7 @@ def reschedule_dialog(user_id: int, dialog: str, planned_date: datetime, phase: 
     Returns:
 
     """
+
     component = get_intervention_component(dialog)
     dialog_id = component.intervention_component_id
     trigger = component.intervention_component_trigger


### PR DESCRIPTION
Fixes: https://github.com/PerfectFit-project/virtual-coach-issues/issues/392
Fixes: https://github.com/PerfectFit-project/testing-tickets/issues/24

- Check for the time before scheduling and before triggering a scheduled task. If the task occurs in nighttime, it is moved to the next morning 
- Avoid checking for the dialog status in the night.