### PR TITLE
415 correct weekly reflection triggering

### DIFF
--- a/scheduler/state_machine/controller.py
+++ b/scheduler/state_machine/controller.py
@@ -432,7 +432,7 @@ class ExecutionRunState(State):
 
             # if in week 3 or 8 of the execution, run future self after
             # completing the weekly reflection
-            if week in [3, 8]:
+            elif week in [3, 8]:
                 logging.info('Starting future self')
                 plan_and_store(user_id=self.user_id,
                                dialog=Components.FUTURE_SELF_SHORT,

--- a/scheduler/state_machine/state_machine_utils.py
+++ b/scheduler/state_machine/state_machine_utils.py
@@ -466,7 +466,7 @@ def get_execution_week(user_id: int) -> int:
                 .filter(Users.nicedayuid == user_id)
                 .one())
 
-    week_number = selected.execution_week
+    week_number = int(selected.execution_week)
 
     return week_number
 

--- a/scheduler/state_machine/state_machine_utils.py
+++ b/scheduler/state_machine/state_machine_utils.py
@@ -74,6 +74,45 @@ def create_new_date(start_date: date,
     return new_timedate
 
 
+def get_all_scheduled_occurrence(user_id: int,
+                                 intervention_component_id: int,
+                                 current_date: datetime) -> Optional[UserInterventionState]:
+    """
+    Gets the all the intervention component occurrences planned for the future and not completed
+
+    Args:
+        user_id: the id of the user
+        intervention_component_id: the id of the intervention component as
+            saved in the DB
+        current_date: the date after which look for the planned component
+
+    Returns:
+            All the occurrence planned for the future and saved in the user_intervention_state
+            table in the DB for the given user and intervention component.
+            A list of UserInterventionState object is returned.
+            In case no entry is found, it returns None
+    """
+    session = get_db_session(DATABASE_URL)
+
+    try:
+        selected = (
+            session.query(
+                UserInterventionState
+            )
+            .filter(
+                UserInterventionState.users_nicedayuid == user_id,
+                UserInterventionState.intervention_component_id == intervention_component_id,
+                UserInterventionState.next_planned_date > current_date
+            )
+            .order_by(UserInterventionState.next_planned_date.asc())  # order by ascending date
+            .all()
+        )
+    except NoResultFound:
+        selected = None
+
+    return selected
+
+
 def get_dialog_completion_state(user_id: int, dialog_name: str) -> Optional[bool]:
     """
     Get the completion state of the last dialog occurrence in the DB
@@ -182,7 +221,7 @@ def get_last_scheduled_occurrence(user_id: int,
 
 def get_next_scheduled_occurrence(user_id: int,
                                   intervention_component_id: int,
-                                  current_date: datetime):
+                                  current_date: datetime) -> Optional[UserInterventionState]:
     """
     Gets the next planned intervention component occurrence
 


### PR DESCRIPTION
Fixes https://github.com/PerfectFit-project/virtual-coach-issues/issues/415

Check if the conditions for running the weekly reflection dialog are met ager the completion of the GA dialog in the execution phase. The conditions come from the [intervention timings](https://leidenuniv1.sharepoint.com/:x:/r/sites/TeamAio/_layouts/15/Doc.aspx?sourcedoc=%7B1B69D6E4-49AA-438A-B3F2-602CEDBBFF9E%7D&file=2022.10.10_Perfect%20Fit%20app%20bible%20(Content%20overview%20and%20planning).xlsx&action=default&mobileredirect=true) and they are meant to distinguish a user-triggered GA dialog from a planned one.