### PR TITLE
444 delay trigger fs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@ pylint==2.15.4
 pytest
 pytest-cov
 pytest-asyncio
-pytype
+pytype<=2023.7.28


### PR DESCRIPTION
Fixes https://github.com/PerfectFit-project/virtual-coach-issues/issues/444

In order to avoid the messages of two consecutive dialogs to overlap in the execution phase: 

- Added a delay between the end of the weekly reflection and the beginning of the future self video.
- Added a delay between the end of the general activity dialog  and the beginning of the weekly reflection.