### PR TITLE
set timezone in controller

### DIFF
--- a/scheduler/state_machine/state_machine_utils.py
+++ b/scheduler/state_machine/state_machine_utils.py
@@ -70,7 +70,8 @@ def create_new_date(start_date: date,
 
     """
     new_date = start_date + timedelta(days=time_delta)
-    new_timedate = datetime(new_date.year, new_date.month, new_date.day, hour, minute)
+    new_timedate = datetime(new_date.year, new_date.month, new_date.day, hour, minute,
+                            tzinfo=TIMEZONE)
 
     return new_timedate
 


### PR DESCRIPTION
Fixes https://github.com/PerfectFit-project/virtual-coach-issues/issues/447

Modified the function in charge of creating the time values for the planning of dialogs in the controller. The times are now in the correct timezone.