### PR TITLE
fixed the logic for checking the duraiton of the tracking state

### DIFF
--- a/scheduler/state_machine/controller.py
+++ b/scheduler/state_machine/controller.py
@@ -10,7 +10,7 @@ from state_machine.state_machine_utils import (create_new_date, get_dialog_compl
                                                get_preferred_date_time,
                                                get_quit_date, get_pa_group, get_start_date,
                                                is_new_week, plan_and_store, reschedule_dialog,
-                                               retrieve_intervention_day, revoke_execution,
+                                               retrieve_tracking_day, revoke_execution,
                                                run_uncompleted_dialog, run_option_menu,
                                                schedule_next_execution, store_completed_dialog,
                                                store_scheduled_dialog, update_execution_week,
@@ -234,10 +234,8 @@ class TrackingState(State):
 
     def on_new_day(self, current_date: date):
         logging.info('current date: %s', current_date)
-        self.check_if_end_date(current_date)
 
         # at day 7 activity C2.9 has to be proposed
-
         start_date = get_start_date(self.user_id)
         ga_completed = get_dialog_completion_state(self.user_id, Components.GENERAL_ACTIVITY)
         if (current_date - start_date).days >= ACTIVITY_C2_9_DAY_TRIGGER and not ga_completed:
@@ -245,10 +243,12 @@ class TrackingState(State):
                            dialog=Components.GENERAL_ACTIVITY,
                            phase_id=1)
 
+        self.check_if_end_date(current_date)
+
     def check_if_end_date(self, date_to_check: date) -> bool:
-        intervention_day = retrieve_intervention_day(self.user_id, date_to_check)
+        tracking_day = retrieve_tracking_day(self.user_id, date_to_check)
         # the Goal Setting state starts on day 10 of the intervention
-        if intervention_day >= TRACKING_DURATION:
+        if tracking_day >= TRACKING_DURATION:
             self.set_new_state(GoalsSettingState(self.user_id))
             return True
 

--- a/scheduler/state_machine/state_machine_utils.py
+++ b/scheduler/state_machine/state_machine_utils.py
@@ -752,9 +752,9 @@ def retrieve_tracking_day(user_id: int, current_date: date) -> int:
 
     # if the dialog has not been admnistered or not completed, return 0
     if track_dialog is None:
-        intervention_day = 0
+        tracking_day = 0
     elif not track_dialog.completed:
-        intervention_day = 0
+        tracking_day = 0
     else:
         start_date = track_dialog.last_time
 

--- a/scheduler/state_machine/state_machine_utils.py
+++ b/scheduler/state_machine/state_machine_utils.py
@@ -734,25 +734,34 @@ def run_option_menu(user_id: int):
     celery.send_task(TRIGGER_INTENT, (user_id, ComponentsTriggers.CENTRAL_OPTIONS, False))
 
 
-def retrieve_intervention_day(user_id: int, current_date: date) -> int:
+def retrieve_tracking_day(user_id: int, current_date: date) -> int:
     """
-    Computes the number of days from the start day of the intervention
-    (first day of preparation phase)
+    Computes the number of days from the start day of the tracking
+    (completion of the track smoking behavior dialog)
 
     Args:
         user_id: ID of the user
         current_date: the current date
 
     Returns:
-        The number of days since  the intervention start day
+        The number of days since the tracking start day
 
     """
-    start_date = get_start_date(user_id=user_id)
+    track_dialog_id = get_intervention_component(Components.PROFILE_CREATION)
+    track_dialog = get_last_component_state(user_id, track_dialog_id)
 
-    # add +1 because the count starts at day 1
-    intervention_day = (current_date - start_date).days + 1
+    # if the dialog has not been admnistered or not completed, return 0
+    if track_dialog is None:
+        intervention_day = 0
+    elif not track_dialog.completed:
+        intervention_day = 0
+    else:
+        start_date = track_dialog.last_time
 
-    return intervention_day
+        # add +1 because the count starts at day 1
+        tracking_day = (current_date - start_date).days + 1
+
+    return tracking_day
 
 
 def store_rescheduled_dialog(user_id: int,


### PR DESCRIPTION
Fixes https://github.com/PerfectFit-project/virtual-coach-issues/issues/459

The tracking duration was computed from the first day of the preparation, but it actually starts after the tracking behavior dialog has been completed. This has been changed by checking the completion time of the dialog.

Also, the need of administering the general activity dialog is now checked before moving the the goal setting.