### PR TITLE
452 missing step goal notification

### DIFF
--- a/scheduler/state_machine/controller.py
+++ b/scheduler/state_machine/controller.py
@@ -177,8 +177,11 @@ class OnboardingState(State):
         first_date = date.today() + timedelta(days=1)
         last_date = get_start_date(self.user_id) + timedelta(days=9)
 
-        plan_every_day_range(self.user_id,
-                             Notifications.TRACK_NOTIFICATION, 1, first_date, last_date)
+        plan_every_day_range(user_id=self.user_id,
+                             dialog=Notifications.TRACK_NOTIFICATION,
+                             phase_id=1,
+                             first_date=first_date,
+                             last_date=last_date)
 
 
 class TrackingState(State):
@@ -354,11 +357,11 @@ class GoalsSettingState(State):
                                phase_id=2)
         # every day (default group 1)
         else:
-            plan_every_day_range(self.user_id,
-                                 Notifications.PA_STEP_GOAL_NOTIFICATION,
-                                 2,
-                                 first_date,
-                                 last_date)
+            plan_every_day_range(user_id=self.user_id,
+                                 dialog=Notifications.PA_STEP_GOAL_NOTIFICATION,
+                                 phase_id=2,
+                                 first_date=first_date,
+                                 last_date=last_date)
 
     def run(self):
 
@@ -633,11 +636,11 @@ class ExecutionRunState(State):
             # until the next GA dialog
             last_date = get_next_planned_date(self.user_id, datetime.now())
 
-            plan_every_day_range(self.user_id,
-                                 Notifications.PA_STEP_GOAL_NOTIFICATION,
-                                 2,
-                                 first_date,
-                                 last_date.date())
+            plan_every_day_range(user_id=self.user_id,
+                                 dialog=Notifications.PA_STEP_GOAL_NOTIFICATION,
+                                 phase_id=2,
+                                 first_date=first_date,
+                                 last_date=last_date.date())
 
     def is_weekly_reflection_next(self) -> bool:
         """

--- a/scheduler/state_machine/controller.py
+++ b/scheduler/state_machine/controller.py
@@ -346,19 +346,8 @@ class GoalsSettingState(State):
         first_date = date.today() + timedelta(days=1)
         # until the execution starts
         last_date = get_quit_date(self.user_id)
-        # every day
-        if pa_group == LOW_PA_GROUP:
 
-            for day in range((last_date - first_date).days + 1):
-                planned_date = create_new_date(start_date=first_date,
-                                               time_delta=day)
-
-                plan_and_store(user_id=self.user_id,
-                               dialog=Notifications.PA_STEP_GOAL_NOTIFICATION,
-                               planned_date=planned_date,
-                               phase_id=2)
-
-        else:
+        if pa_group == HIGH_PA_GROUP:
             # every 3 days
             for day in range((last_date - first_date).days)[0::3]:
                 planned_date = create_new_date(start_date=first_date,
@@ -366,6 +355,16 @@ class GoalsSettingState(State):
 
                 plan_and_store(user_id=self.user_id,
                                dialog=Notifications.PA_INTENSITY_MINUTES_NOTIFICATION,
+                               planned_date=planned_date,
+                               phase_id=2)
+        # every day (default group 1)
+        else:
+            for day in range((last_date - first_date).days + 1):
+                planned_date = create_new_date(start_date=first_date,
+                                               time_delta=day)
+
+                plan_and_store(user_id=self.user_id,
+                               dialog=Notifications.PA_STEP_GOAL_NOTIFICATION,
                                planned_date=planned_date,
                                phase_id=2)
 

--- a/scheduler/state_machine/controller.py
+++ b/scheduler/state_machine/controller.py
@@ -18,7 +18,7 @@ from state_machine.state_machine_utils import (create_new_date, get_dialog_compl
                                                update_fsm_dialog_running_status)
 from state_machine.const import (ACTIVITY_C2_9_DAY_TRIGGER, FUTURE_SELF_INTRO, GOAL_SETTING,
                                  TRACKING_DURATION, TIMEZONE, PREPARATION_GA, PAUSE_AND_TRIGGER,
-                                 MAX_PREPARATION_DURATION, LOW_PA_GROUP, HIGH_PA_GROUP,
+                                 MAX_PREPARATION_DURATION, HIGH_PA_GROUP,
                                  EXECUTION_DURATION_WEEKS, TIME_DELTA_PA_NOTIFICATION, REDIS_URL,
                                  RESCHEDULE_DIALOG, TRIGGER_INTENT)
 from state_machine.state import State

--- a/scheduler/state_machine/controller.py
+++ b/scheduler/state_machine/controller.py
@@ -615,22 +615,7 @@ class ExecutionRunState(State):
 
         pa_group = get_pa_group(self.user_id)
 
-        if pa_group == LOW_PA_GROUP:
-
-            first_date = date.today() + timedelta(days=1)
-            # until the next GA dialog
-            last_date = first_date + timedelta(days=6)
-
-            for day in range((last_date - first_date).days):
-                planned_date = create_new_date(start_date=first_date,
-                                               time_delta=day)
-
-                plan_and_store(user_id=self.user_id,
-                               dialog=Notifications.PA_STEP_GOAL_NOTIFICATION,
-                               planned_date=planned_date,
-                               phase_id=2)
-
-        elif pa_group == HIGH_PA_GROUP:
+        if pa_group == HIGH_PA_GROUP:
 
             planned_date_1 = create_new_date(start_date=date.today(),
                                              time_delta=1)
@@ -647,6 +632,21 @@ class ExecutionRunState(State):
                            dialog=Notifications.PA_INTENSITY_MINUTES_NOTIFICATION,
                            planned_date=planned_date_4,
                            phase_id=2)
+
+        else:
+
+            first_date = date.today() + timedelta(days=1)
+            # until the next GA dialog
+            last_date = first_date + timedelta(days=6)
+
+            for day in range((last_date - first_date).days):
+                planned_date = create_new_date(start_date=first_date,
+                                               time_delta=day)
+
+                plan_and_store(user_id=self.user_id,
+                               dialog=Notifications.PA_STEP_GOAL_NOTIFICATION,
+                               planned_date=planned_date,
+                               phase_id=2)
 
     def is_weekly_reflection_next(self) -> bool:
         """

--- a/scheduler/state_machine/controller.py
+++ b/scheduler/state_machine/controller.py
@@ -637,7 +637,7 @@ class ExecutionRunState(State):
                                  Notifications.PA_STEP_GOAL_NOTIFICATION,
                                  2,
                                  first_date,
-                                 last_date)
+                                 last_date.date())
 
     def is_weekly_reflection_next(self) -> bool:
         """

--- a/scheduler/state_machine/state_machine_utils.py
+++ b/scheduler/state_machine/state_machine_utils.py
@@ -935,6 +935,31 @@ def plan_and_store(user_id: int,
                                last_time=last_time)
 
 
+def plan_every_day_range(user_id: int,
+                         dialog: str,
+                         phase_id: int,
+                         first_date: datetime,
+                         last_date: datetime):
+    """
+    Program a dialog every day from the first date to the last date.
+    Args:
+        user_id:user id
+        dialog: dialog to be triggered
+        phase_id: db id of the phase
+        first_date: first date where the dialog is planned
+        last_date: last date where the dialog is planned
+    """
+
+    for day in range((last_date - first_date).days + 1):
+        planned_date = create_new_date(start_date=first_date,
+                                       time_delta=day)
+
+        plan_and_store(user_id=user_id,
+                       dialog=dialog,
+                       planned_date=planned_date,
+                       phase_id=phase_id)
+
+
 def reschedule_dialog(user_id: int, dialog: str, planned_date: datetime, phase: int):
     """
     Program a new celery task for the planned_date and store the info in the db

--- a/scheduler/state_machine/state_machine_utils.py
+++ b/scheduler/state_machine/state_machine_utils.py
@@ -938,8 +938,8 @@ def plan_and_store(user_id: int,
 def plan_every_day_range(user_id: int,
                          dialog: str,
                          phase_id: int,
-                         first_date: datetime,
-                         last_date: datetime):
+                         first_date: date,
+                         last_date: date):
     """
     Program a dialog every day from the first date to the last date.
     Args:


### PR DESCRIPTION
Fixes https://github.com/PerfectFit-project/virtual-coach-issues/issues/452
Fixes https://github.com/PerfectFit-project/testing-tickets/issues/73

- Added the missing notifications between the quit date and the first general activity
- Default PA group to 1 in case no PA group has been set
- Grouped redundant code in a single function to schedule the PA notifications