### PR TITLE
Fix case no data available for step goal calculation

### DIFF
--- a/sensor_api/sensorapi/connector.py
+++ b/sensor_api/sensorapi/connector.py
@@ -202,11 +202,15 @@ def get_step_goals_and_steps(steps_data: Optional[List[Dict[Any, Any]]],
         steps_nine_days = steps[i:i + 9]
         steps_nine_days = [x for x in steps_nine_days if not pd.isna(x)]  # Remove NaN values
 
-        for _ in range(9 - len(steps_nine_days)):
-            steps_nine_days.append(np.mean(steps_nine_days))  # Add the avg value up to 9 values
+        if not steps_nine_days:
+            step_goals.append(MIN_VALUE_STEP_GOAL)
 
-        steps_nine_days.sort()
-        step_goals.append(int(round(steps_nine_days[5], -1)))  # Definition of the goal
+        else:
+            for _ in range(9 - len(steps_nine_days)):
+                steps_nine_days.append(np.mean(steps_nine_days))  # Add the avg value up to 9 values
+
+            steps_nine_days.sort()
+            step_goals.append(int(round(steps_nine_days[5], -1)))  # Definition of the goal
 
     # Minimum goal is 2000, max is 10.000 steps/per day.
     step_goals = min_max_step_goal(step_goals)


### PR DESCRIPTION
Fixes: https://github.com/PerfectFit-project/virtual-coach-issues/issues/460

What was going wrong: if there was no data from 9 days where the step goal should have been calculated, a NaN value was rounded, which gave the error. 

Fixed by checking if the data is empty or not, if empty, the goal is directly set to the minimum value.