### PR TITLE
split utterance, remove klaar from form validation, retrain

### DIFF
--- a/Rasa_Bot/actions/actions_weekly_reflection.py
+++ b/Rasa_Bot/actions/actions_weekly_reflection.py
@@ -715,7 +715,6 @@ class ValidateUserReady1Form(FormValidationAction):
 
         if not validator.validate_klaar(value):
             dispatcher.utter_message(response="utter_did_not_understand")
-            dispatcher.utter_message(response="utter_please_answer_klaar")
             return {"user_ready_1": None}
 
         return {"user_ready_1": value}

--- a/Rasa_Bot/data/rules/rules_weekly_reflection_dialog.yml
+++ b/Rasa_Bot/data/rules/rules_weekly_reflection_dialog.yml
@@ -452,7 +452,8 @@ rules:
   - action: utter_look_forward_9
   - action: utter_look_forward_10
   - action: utter_look_forward_11
-  - action: utter_look_forward_12
+  - action: utter_look_forward_12_a
+  - action: utter_look_forward_12_b
   - action: user_ready_1_form
   - active_loop: user_ready_1_form
   wait_for_user_input: false

--- a/Rasa_Bot/domain/domain_watching_a_video.yml
+++ b/Rasa_Bot/domain/domain_watching_a_video.yml
@@ -50,7 +50,7 @@ responses:
     - text: "Je zal nu even de app verlaten, maar je komt daarna weer terug. Ik zal je uitleggen hoe je dat kunt doen."
   utter_watch_video_waiting:
     - text: "Ik geef je nu even wat tijd om de video te bekijken."
-    - text: "Ik laat je even de tijd om de video te bekijken."
+    - text: "Ik geef je even de tijd om de video te bekijken."
     - text: "Ik geef je nu een moment om de video te bekijken."
   utter_thanks_for_watching:
     - text: "Bedankt voor het kijken van de video! Was alles duidelijk of wil je hem nog een keer bekijken?"

--- a/Rasa_Bot/domain/domain_weekly_reflection_dialog.yml
+++ b/Rasa_Bot/domain/domain_weekly_reflection_dialog.yml
@@ -573,6 +573,8 @@ responses:
     - text: "Neem hier wat tijd voor."
   utter_ask_user_ready_1:
     - text: "Typ 'klaar' als je hier klaar mee bent."
+    - text: "Zodra je klaar bent, kun je verder gaan door 'klaar' te typen."
+    - text: "Laat me weten wanneer je klaar bent door 'klaar' te typen."
   utter_look_forward_13:
     - text: "Mooi! Het is handig om je plan bij de hand te houden zodat je altijd even kan terugkijken wat je had
              bedacht. Je kan het papier bijvoorbeeld in het hoesje van je telefoon bewaren. Je kan anders ook een

--- a/Rasa_Bot/domain/domain_weekly_reflection_dialog.yml
+++ b/Rasa_Bot/domain/domain_weekly_reflection_dialog.yml
@@ -567,10 +567,12 @@ responses:
     - text: "🖊️ Pak pen en papier en schrijf 1 of 2 dingen op die jij komende week nieuw of opnieuw gaat doen om niet te roken."
   utter_look_forward_11:
     - text: "Een voorbeeld is: 'Komende week ga ik mijn vrienden opnieuw vragen om niet te roken als ik erbij ben'. "
-  utter_look_forward_12:
-    - text: "Een ander voorbeeld is: 'Komende week ga ik buiten wandelen op momenten dat ik vroeger zou roken.' "
+  utter_look_forward_12_a:
+    - text: "Een ander voorbeeld is: 'Komende week ga ik buiten wandelen op momenten dat ik vroeger zou roken.'"
+  utter_look_forward_12_b:
+    - text: "Neem hier wat tijd voor."
   utter_ask_user_ready_1:
-    - text: "Neem hier wat tijd voor. Typ 'klaar' als je hier klaar mee bent. "
+    - text: "Typ 'klaar' als je hier klaar mee bent."
   utter_look_forward_13:
     - text: "Mooi! Het is handig om je plan bij de hand te houden zodat je altijd even kan terugkijken wat je had
              bedacht. Je kan het papier bijvoorbeeld in het hoesje van je telefoon bewaren. Je kan anders ook een


### PR DESCRIPTION
Fixes https://github.com/PerfectFit-project/virtual-coach-issues/issues/464.
Fixes https://github.com/PerfectFit-project/testing-tickets/issues/81 (corresponding testing issue.)
Fixes https://github.com/PerfectFit-project/virtual-coach-issues/issues/467

- Split form introduction sentence to remove the part about taking time so that it is not repeated when the form is not filled successfully.
- Removed the extra klaar utterance as part of the form validation.
- Fixed typo in video watching dialog.