### PR TITLE
changed formulation help not available message

### DIFF
--- a/Rasa_Bot/domain/domain_common.yml
+++ b/Rasa_Bot/domain/domain_common.yml
@@ -61,7 +61,7 @@ responses:
             De Stoplijn is van maandag t/m vrijdag bereikbaar van 9 tot 17 uur."
 
   utter_help_not_available:
-    - text: "Je bent nu in de voorbereidingsfase. Je kunt ‘help’ gebruiken tijdens de uitvoeringsfase."
+    - text: "Je bent nu niet in de uitvoeringsfase. Je kunt 'help' gebruiken tijdens de uitvoeringsfase."
 
 
   utter_ehbo_not_available:


### PR DESCRIPTION
Fixes https://github.com/PerfectFit-project/virtual-coach-issues/issues/468.

Changed the formulation for the message sent when the help functionality is not available.