### PR TITLE
fix: schedule weekly reflection when not automatically scheduled

### DIFF
--- a/scheduler/state_machine/controller.py
+++ b/scheduler/state_machine/controller.py
@@ -614,9 +614,11 @@ class ExecutionRunState(State):
 
         # get the date of the previous preferred day
         last_preferred_day = compute_previous_day(self.user_id, current_date)
+        quit_date = get_quit_date()
 
-        # make sure that today is not the preferred day
-        if last_preferred_day != current_date:
+        # make sure that today is not the preferred day, and that the previous
+        # preferred day was in the running phase (i.e., after the quit date )
+        if last_preferred_day != current_date and last_preferred_day > quit_date:
             component = get_intervention_component(Components.WEEKLY_REFLECTION)
             # get the general activity dialog that have been scheduled after the
             # last preferred date

--- a/scheduler/state_machine/controller.py
+++ b/scheduler/state_machine/controller.py
@@ -614,7 +614,7 @@ class ExecutionRunState(State):
 
         # get the date of the previous preferred day
         last_preferred_day = compute_previous_day(self.user_id, current_date)
-        quit_date = get_quit_date()
+        quit_date = get_quit_date(self.user_id)
 
         # make sure that today is not the preferred day, and that the previous
         # preferred day was in the running phase (i.e., after the quit date )

--- a/scheduler/state_machine/controller.py
+++ b/scheduler/state_machine/controller.py
@@ -620,11 +620,15 @@ class ExecutionRunState(State):
         # preferred day was in the running phase (i.e., after the quit date )
         if last_preferred_day != current_date and last_preferred_day > quit_date:
             component = get_intervention_component(Components.WEEKLY_REFLECTION)
+
+            # convert to datetime
+            pref_timedate = datetime.combine(last_preferred_day, datetime.min.time())
+
             # get the general activity dialog that have been scheduled after the
             # last preferred date
             next_scheduled = get_next_scheduled_occurrence(self.user_id,
                                                            component.intervention_component_id,
-                                                           last_preferred_day)
+                                                           pref_timedate)
             # if none have been scheduled, trigger one
             if not next_scheduled:
                 plan_and_store(user_id=self.user_id,

--- a/scheduler/state_machine/state_machine_utils.py
+++ b/scheduler/state_machine/state_machine_utils.py
@@ -57,6 +57,31 @@ def compute_next_day(selectable_days: list, current_date: datetime) -> date:
     return next_date
 
 
+def compute_previous_day(user_id: int, current_date: datetime) -> date:
+    """
+    Gets the date of the last preferred day for a user.
+
+    Args:
+        user_id: the id of the user
+        current_date: the date to start from
+
+    Returns:
+        The date of the last preferred day for a user.
+    """
+
+    date_time = get_preferred_date_time(user_id=user_id)
+
+    # first element of the tuple is the list of days
+    pref_day = date_time[0][0]
+
+    days_to_pref_day = (current_date.isoweekday() - pref_day) % 7
+    days_ago = (days_to_pref_day + 7) % 7
+
+    pref_day_before_today = current_date - timedelta(days=days_ago)
+
+    return pref_day_before_today
+
+
 def create_new_date(start_date: date,
                     time_delta: int = 0,
                     hour: int = 10,

--- a/scheduler/state_machine/state_machine_utils.py
+++ b/scheduler/state_machine/state_machine_utils.py
@@ -72,7 +72,10 @@ def compute_previous_day(user_id: int, current_date: date) -> date:
     date_time = get_preferred_date_time(user_id=user_id)
 
     # first element of the tuple is the list of days
-    pref_day = date_time[0][0]
+    try:
+        pref_day = date_time[0][0]
+    except TypeError:
+        pref_day = 1
 
     days_to_pref_day = (current_date.isoweekday() - pref_day) % 7
     days_ago = (days_to_pref_day + 7) % 7

--- a/scheduler/state_machine/state_machine_utils.py
+++ b/scheduler/state_machine/state_machine_utils.py
@@ -57,7 +57,7 @@ def compute_next_day(selectable_days: list, current_date: datetime) -> date:
     return next_date
 
 
-def compute_previous_day(user_id: int, current_date: datetime) -> date:
+def compute_previous_day(user_id: int, current_date: date) -> date:
     """
     Gets the date of the last preferred day for a user.
 


### PR DESCRIPTION
Fixes https://github.com/PerfectFit-project/virtual-coach-issues/issues/482

During the execution phase, every day the the state machine checks if the weekly reflection dialog has been planned for the current week. It retrieves the last date when the weekly reflection should have been sent and, if no new weekly reflection has been sent nor planned, it triggers the dialog.