### PR TITLE
Adds the notification to tracking state

### DIFF
--- a/Rasa_Bot/data/rules/rules_notifications.yml
+++ b/Rasa_Bot/data/rules/rules_notifications.yml
@@ -8,6 +8,7 @@ rules:
   - action: utter_notifications_tracking_1
   - action: utter_notifications_tracking_2
   - action: utter_notifications_tracking_3
+  - action: action_notifications_check_watch_wear
   - action: pause_one_minute
 
 ## Step goal notification


### PR DESCRIPTION
From what I am seeing, the tracking state notification is a daily notification triggered after the completion of the tracking dialog, and it's the only place after the onboarding where we don't send notifications to the user to ensure that they wear the watch and collect data. 
It seems as if adding this single line should do the trick, from what I've looked at, but I'm not completely sure, so I also wouldn't mind making a different notification to add to this state.