### PR TITLE
Mark dialogs as completed after ending dialog

### DIFF
--- a/Rasa_Bot/actions/actions_relapse_dialogs.py
+++ b/Rasa_Bot/actions/actions_relapse_dialogs.py
@@ -38,7 +38,8 @@ class ActionCheckReasons(Action):
 
         if '6' in reasons:
             dispatcher.utter_message(response="utter_pa_sick")
-            return [FollowupAction("action_end_dialog")]
+            return [FollowupAction('action_end_dialog'),
+                    FollowupAction('mark_dialog_as_completed')]
 
         return []
 

--- a/Rasa_Bot/actions/actions_relapse_dialogs.py
+++ b/Rasa_Bot/actions/actions_relapse_dialogs.py
@@ -38,8 +38,8 @@ class ActionCheckReasons(Action):
 
         if '6' in reasons:
             dispatcher.utter_message(response="utter_pa_sick")
-            return [FollowupAction('action_end_dialog'),
-                    FollowupAction('mark_dialog_as_completed')]
+            return [FollowupAction('mark_dialog_as_completed'),
+                    FollowupAction('action_end_dialog')]
 
         return []
 

--- a/Rasa_Bot/actions/actions_relapse_dialogs.py
+++ b/Rasa_Bot/actions/actions_relapse_dialogs.py
@@ -13,7 +13,8 @@ from .helper import (figure_has_data,
                      populate_fig,
                      store_dialog_closed_answer_list_to_db,
                      store_dialog_closed_answer_to_db,
-                     store_dialog_open_answer_to_db)
+                     store_dialog_open_answer_to_db,
+                     mark_completion)
 from celery import Celery
 from rasa_sdk import Action, Tracker
 from rasa_sdk.events import SlotSet, FollowupAction
@@ -36,10 +37,13 @@ class ActionCheckReasons(Action):
     async def run(self, dispatcher, tracker, domain):
         reasons = tracker.get_slot('pa_why_fail')
 
+        user_id = int(tracker.current_state()['sender_id'])  # retrieve userID
+        slot = tracker.get_slot("current_intervention_component")
+
         if '6' in reasons:
             dispatcher.utter_message(response="utter_pa_sick")
-            return [FollowupAction('mark_dialog_as_completed'),
-                    FollowupAction('action_end_dialog')]
+            mark_completion(user_id, slot)
+            return [FollowupAction('action_end_dialog')]
 
         return []
 

--- a/Rasa_Bot/actions/actions_weekly_reflection.py
+++ b/Rasa_Bot/actions/actions_weekly_reflection.py
@@ -190,8 +190,8 @@ class GetWeekNumber(Action):
         user_info = get_user(user_id)
         exec_week = user_info.execution_week
         if exec_week > 11:
-            return [FollowupAction('action_end_dialog'),
-                    FollowupAction('mark_dialog_as_completed')]
+            return [FollowupAction('mark_dialog_as_completed'),
+                    FollowupAction('action_end_dialog')]
         return [SlotSet('week_number', str(exec_week))]
 
 

--- a/Rasa_Bot/actions/actions_weekly_reflection.py
+++ b/Rasa_Bot/actions/actions_weekly_reflection.py
@@ -27,7 +27,8 @@ from .helper import (get_intensity_minutes_goal,
                      make_step_overview,
                      set_intensity_minutes_goal,
                      set_pa_group_to_db,
-                     store_dialog_part_to_db)
+                     store_dialog_part_to_db,
+                     mark_completion)
 from virtual_coach_db.helper.definitions import Components
 from sensorapi.connector import get_steps_data, get_step_goals_and_steps, get_intensity_minutes_data
 
@@ -187,11 +188,12 @@ class GetWeekNumber(Action):
 
     async def run(self, dispatcher, tracker, domain):
         user_id = int(tracker.current_state()['sender_id'])  # retrieve userID
+        slot = tracker.get_slot("current_intervention_component")
         user_info = get_user(user_id)
         exec_week = user_info.execution_week
         if exec_week > 11:
-            return [FollowupAction('mark_dialog_as_completed'),
-                    FollowupAction('action_end_dialog')]
+            mark_completion(user_id, slot)
+            return [FollowupAction('action_end_dialog')]
         return [SlotSet('week_number', str(exec_week))]
 
 

--- a/Rasa_Bot/actions/actions_weekly_reflection.py
+++ b/Rasa_Bot/actions/actions_weekly_reflection.py
@@ -190,7 +190,8 @@ class GetWeekNumber(Action):
         user_info = get_user(user_id)
         exec_week = user_info.execution_week
         if exec_week > 11:
-            return [FollowupAction('action_end_dialog')]
+            return [FollowupAction('action_end_dialog'),
+                    FollowupAction('mark_dialog_as_completed')]
         return [SlotSet('week_number', str(exec_week))]
 
 


### PR DESCRIPTION
User got notifications after a dialog was ended for this particular dialog, which implied that the dialog hadn't been marked as completed. 'action_end_dialog' is deceptive as it doesn't really do anything right now, but mark_dialog_completed is important to conclude with so the State Machine updates the dialog as not running anymore.